### PR TITLE
Rebrand application messaging to CiKr

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Adventure Ready Rentals
+# CiKr
 
-Adventure Ready Rentals is a React application that mimics a React Native project so the same component layer can serve web and future native targets.  The UI has been rebuilt using React Native primitives such as `View`, `Text`, and `ScrollView`, all powered by a lightweight custom implementation that renders to the DOM.
+CiKr is a React application that mimics a React Native project so the same component layer can serve web and future native targets. The UI has been rebuilt using React Native primitives such as `View`, `Text`, and `ScrollView`, all powered by a lightweight custom implementation that renders to the DOM.
 
 ## Getting Started
 

--- a/index.html
+++ b/index.html
@@ -3,12 +3,18 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>AdventureRent - Rent Amazing Adventure Gear</title>
-    <meta name="description" content="Rent amazing adventure gear from local owners. Climbing, camping, water sports, and winter gear available near you." />
-    <meta name="author" content="AdventureRent" />
+    <title>CiKr – Discover Your Next Trail with Local Gear</title>
+    <meta
+      name="description"
+      content="CiKr makes it easy to borrow local outdoor gear with upfront pricing, optional insurance, and eco-friendly reuse."
+    />
+    <meta name="author" content="CiKr" />
 
-    <meta property="og:title" content="AdventureRent - Rent Amazing Adventure Gear" />
-    <meta property="og:description" content="Rent amazing adventure gear from local owners. Climbing, camping, water sports, and winter gear available near you." />
+    <meta property="og:title" content="CiKr – Discover Your Next Trail with Local Gear" />
+    <meta
+      property="og:description"
+      content="Plan your next adventure with trusted local owners, clear fees, and community-backed sustainability on CiKr."
+    />
     <meta property="og:type" content="website" />
     <meta property="og:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "adventure-ready-rentals",
+  "name": "cikr",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/src/components/Categories.tsx
+++ b/src/components/Categories.tsx
@@ -8,25 +8,26 @@ const categories = [
   {
     id: "climbing",
     title: "Climbing",
-    description: "Harnesses, ropes, and protection curated for alpine legends and boulder newcomers alike.",
+    description:
+      "Harnesses, ropes, and protection maintained by local climbers so first-timers and pros feel secure.",
     imageUri: "https://images.unsplash.com/photo-1509644851220-51ebdcca412f?auto=format&fit=crop&w=1200&q=80",
   },
   {
     id: "camping",
     title: "Camping",
-    description: "From ultralight shelters to luxe family glamping setups ready for every trailhead.",
+    description: "From ultralight shelters to cozy family tents shared by neighbours who love seeing gear reused.",
     imageUri: "https://images.unsplash.com/photo-1525104698733-6d46d76471e6?auto=format&fit=crop&w=1200&q=80",
   },
   {
     id: "water",
     title: "Water sports",
-    description: "Kayaks, SUPs, and wetsuits designed for lakeside dawn patrols and coastal escapes.",
+    description: "Kayaks, SUPs, and wetsuits paired with safety gear from paddlers who know the local waters best.",
     imageUri: "https://images.unsplash.com/photo-1525182008055-f88b95ff7980?auto=format&fit=crop&w=1200&q=80",
   },
   {
     id: "winter",
     title: "Winter pursuits",
-    description: "Skis, boards, and avalanche safety kits to chase powder days across every summit.",
+    description: "Skis, boards, and avalanche kits tuned by mountain regulars to keep every glide confident and low impact.",
     imageUri: "https://images.unsplash.com/photo-1454433720423-8246b00b557d?auto=format&fit=crop&w=1200&q=80",
   },
 ];
@@ -38,10 +39,10 @@ const Categories = () => {
     <View style={styles.container}>
       <View style={styles.header}>
         <Text style={styles.overline}>Categories</Text>
-        <Text style={styles.title}>Find the right gear faster</Text>
+        <Text style={styles.title}>Choose a path and borrow with confidence</Text>
         <Text style={styles.subtitle}>
-          Browse expertly curated collections that highlight our most popular adventures, all optimized for
-          touch-friendly mobile and responsive web layouts.
+          These collections highlight community favourites so you can plan with transparent pricing, trusted
+          safety gear, and a lighter footprint.
         </Text>
       </View>
       <ScrollView

--- a/src/components/FeaturedGear.tsx
+++ b/src/components/FeaturedGear.tsx
@@ -7,7 +7,8 @@ import GearCard from "./GearCard";
 const featuredGear = [
   {
     title: "Summit Series Mountaineering Kit",
-    description: "Technical outerwear, crampons, and glacier travel essentials ready for expedition season.",
+    description:
+      "Technical layers, crampons, and glacier essentials with clear insurance options for your next ascent.",
     pricePerDay: 128,
     rating: 4.9,
     reviewCount: 184,
@@ -16,7 +17,8 @@ const featuredGear = [
   },
   {
     title: "Family Basecamp Bundle",
-    description: "Spacious 6-person tent, cozy sleep system, and camp kitchen built for week-long escapes.",
+    description:
+      "Spacious tent, cozy sleep systems, and a camp kitchen shared by neighbours who love helping families explore.",
     pricePerDay: 92,
     rating: 4.8,
     reviewCount: 136,
@@ -25,7 +27,8 @@ const featuredGear = [
   },
   {
     title: "Coastal Paddle Adventure Pack",
-    description: "Premium touring kayak, dry storage, and navigation tools to explore rugged shorelines.",
+    description:
+      "Premium touring kayak, dry storage, and safety gear guided by locals who know every tide chart.",
     pricePerDay: 78,
     rating: 4.7,
     reviewCount: 98,
@@ -34,7 +37,8 @@ const featuredGear = [
   },
   {
     title: "Backcountry Powder Setup",
-    description: "Carbon touring skis, avalanche kit, and beacon for safe dawn patrol missions.",
+    description:
+      "Carbon touring skis, avalanche tools, and beacon checks so dawn patrols stay thrilling and responsible.",
     pricePerDay: 110,
     rating: 4.9,
     reviewCount: 153,
@@ -51,10 +55,10 @@ const FeaturedGear = () => {
       <View style={styles.header}>
         <View style={styles.headerText}>
           <Text style={styles.overline}>Featured gear</Text>
-          <Text style={styles.title}>Outdoor essentials loved by our community</Text>
+          <Text style={styles.title}>Outdoor essentials shared by our community</Text>
           <Text style={styles.subtitle}>
-            Curated listings highlight how the new React Native experience balances immersive visuals with
-            performant cross-platform rendering.
+            Every highlight spells out daily rates, deposit holds, and optional insurance so you can plan an
+            eco-friendly escape with confidence.
           </Text>
         </View>
         <Pressable
@@ -62,7 +66,7 @@ const FeaturedGear = () => {
           onPress={() => navigate("/browse")}
           style={({ pressed }) => [styles.viewAll, pressed && styles.viewAllPressed]}
         >
-          <Text style={styles.viewAllText}>View all gear</Text>
+          <Text style={styles.viewAllText}>Explore all gear</Text>
         </Pressable>
       </View>
       <View style={styles.grid}>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -9,10 +9,10 @@ const Footer = () => {
   return (
     <View style={styles.container}>
       <View style={styles.brandBlock}>
-        <Text style={styles.brand}>Adventure Ready Rentals</Text>
+        <Text style={styles.brand}>CiKr</Text>
         <Text style={styles.summary}>
-          A single React Native codebase delivering immersive outdoor gear browsing experiences
-          across web and mobile.
+          CiKr connects friendly locals and responsible travelers with clear pricing, optional
+          insurance, and reuse-first adventures across web and mobile.
         </Text>
       </View>
 
@@ -24,7 +24,7 @@ const Footer = () => {
       </View>
 
       <Text style={styles.copyright}>
-        © {new Date().getFullYear()} Adventure Ready Rentals. Built with React Native for every platform.
+        © {new Date().getFullYear()} CiKr. Built with React Native for every platform.
       </Text>
     </View>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -68,8 +68,8 @@ const Header = () => {
           accessibilityRole="link"
           style={({ pressed }) => [styles.brandWrapper, pressed && styles.linkPressed]}
         >
-          <Text style={styles.brand}>Adventure Ready Rentals</Text>
-          <Text style={styles.subtitle}>Gear up for unforgettable outdoor experiences</Text>
+          <Text style={styles.brand}>CiKr</Text>
+          <Text style={styles.subtitle}>Borrow local gear safely and lighten your pack</Text>
         </Pressable>
 
         {isCompact ? (

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -12,12 +12,12 @@ const Hero = () => {
   return (
     <View style={styles.container}>
       <View style={styles.content}>
-        <Text style={styles.subtitle}>One codebase. Every adventure.</Text>
-        <Text style={styles.title}>Rent premium outdoor gear, anywhere you roam.</Text>
+        <Text style={styles.subtitle}>One community. Endless adventures.</Text>
+        <Text style={styles.title}>Discover your next trail with trusted local gear.</Text>
         <Text style={styles.description}>
-          Built with React Native, Adventure Ready Rentals delivers a seamless browsing experience across
-          native mobile apps and the web. Discover curated collections, explore rich gear details, and book
-          with confidence on any device.
+          CiKr brings friendly owners and renters together so you can explore more while buying less. Every
+          listing clearly outlines daily rates, deposits, and insurance options, making it simple to choose
+          the right fit, protect your trip, and reduce waste along the way.
         </Text>
 
         <View style={styles.actions}>
@@ -26,14 +26,14 @@ const Hero = () => {
             onPress={() => navigate("/browse")}
             style={({ pressed }) => [styles.primaryAction, pressed && styles.primaryActionPressed]}
           >
-            <Text style={styles.primaryActionText}>Browse gear</Text>
+            <Text style={styles.primaryActionText}>Discover your next trail</Text>
           </Pressable>
           <Pressable
             accessibilityRole="button"
             onPress={() => navigate("/how-it-works")}
             style={({ pressed }) => [styles.secondaryAction, pressed && styles.secondaryActionPressed]}
           >
-            <Text style={styles.secondaryActionText}>See how it works</Text>
+            <Text style={styles.secondaryActionText}>See how CiKr works</Text>
           </Pressable>
         </View>
       </View>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 import { AppRegistry } from "react-native";
 import App from "./App";
 
-const APP_NAME = "AdventureReadyRentals";
+const APP_NAME = "CiKr";
 
 AppRegistry.registerComponent(APP_NAME, () => App);
 

--- a/src/pages/Architecture.tsx
+++ b/src/pages/Architecture.tsx
@@ -26,32 +26,32 @@ const services: Service[] = [
   {
     name: "Booking Service",
     summary:
-      "Coordinates availability holds, captures deposits, and governs the lifecycle from request to completion.",
+      "Keeps trip requests moving smoothly by holding availability, managing deposits, and tracking every booking from hello to hand-off.",
     responsibilities: [
-      "Validates renter eligibility and policy windows before confirming a trip.",
-      "Publishes Booking.Created/Updated/Cancelled events for downstream services.",
-      "Manages refunds and release of insurance and deposit holds when plans change.",
+      "Checks renter eligibility and policy windows before confirming a trip so everyone stays covered.",
+      "Publishes Booking.Created/Updated/Cancelled events for downstream services without losing transparency.",
+      "Manages refunds plus the release of insurance and deposit holds when plans change.",
     ],
     apis: ["POST /bookings", "POST /bookings/{id}/cancel", "POST /bookings/{id}/mark-completed"],
   },
   {
     name: "Payments & Payouts",
     summary:
-      "Handles deposit pre-authorizations, split payouts, tax boundaries, and KYC workflows for owners.",
+      "Handles deposit holds, split payouts, tax boundaries, and owner verification so money matters stay clear and compliant.",
     responsibilities: [
       "Stores processor tokens and reconciliation metadata without persisting raw PAN data.",
-      "Coordinates deposit capture/release, refunds, and payout schedules with full auditability.",
-      "Surfaces compliance holds and KYC states in renter and owner dashboards.",
+      "Coordinates deposit capture or release, refunds, and payout schedules with full auditability.",
+      "Shows compliance holds and KYC status in renter and owner dashboards so expectations stay aligned.",
     ],
     apis: ["POST /payments/intents", "POST /payments/refunds", "POST /payouts/initiate"],
   },
   {
     name: "Listings & Search",
     summary:
-      "Maintains owner listings, pricing, media assets, and search indices for responsive discovery.",
+      "Maintains listings, pricing, media, and search indices so renters can quickly discover reusable local gear.",
     responsibilities: [
-      "Versioned pricing and availability calendars optimized for geographic filters.",
-      "Image processing pipelines deliver responsive hero and thumbnail assets across platforms.",
+      "Keeps pricing and availability calendars versioned and optimized for geographic filters.",
+      "Processes images so hero shots and thumbnails shine on every platform without slowing things down.",
       "Feeds analytics, booking, and messaging services with normalized listing metadata.",
     ],
     apis: ["POST /listings", "PATCH /listings/{id}", "GET /search?location=..."],
@@ -59,10 +59,10 @@ const services: Service[] = [
   {
     name: "Messaging & Reviews",
     summary:
-      "Creates trusted connections before and after trips with moderated messaging and structured reviews.",
+      "Creates trusted connections before and after trips with moderated messaging and thoughtful reviews.",
     responsibilities: [
-      "Threads renter-owner conversations with retention policies and reporting flows.",
-      "Collects post-trip reviews and sentiment scores consumed by discovery ranking.",
+      "Threads renter-owner conversations with retention policies and friendly reporting flows.",
+      "Collects post-trip reviews and sentiment scores that support fair discovery ranking.",
       "Escalates flagged content to Admin/Ops with append-only audit records.",
     ],
     apis: ["POST /messages", "POST /reports", "POST /reviews"],
@@ -73,20 +73,20 @@ const sequences: Sequence[] = [
   {
     title: "Create booking",
     description:
-      "Demonstrates the orchestration between Listings, Booking, Payments, Insurance, and Messaging services.",
+      "Shows how Listings, Booking, Payments, Insurance, and Messaging team up to give renters a clear, friendly path.",
     steps: [
-      "Renter selects dates and submits a booking request via the React Native interface.",
+      "Renter selects dates and submits a booking request in the shared React Native experience.",
       "Booking service reserves availability and requests a deposit pre-auth from Payments.",
       "Insurance gateway issues a quote and, if accepted, binds coverage for the trip.",
-      "Booking transitions to Confirmed and Messaging notifies both parties with pickup guidance.",
+      "Booking moves to Confirmed and Messaging notifies both parties with pickup guidance.",
     ],
   },
   {
     title: "Resolve a damage claim",
-    description: "Highlights how evidence flows through Insurance, Messaging, and Payments.",
+    description: "Highlights how evidence flows through Insurance, Messaging, and Payments so renters and owners feel supported.",
     steps: [
       "Owner files a claim with photos and notes captured directly in the app, even while offline.",
-      "Insurance gateway validates coverage, requests additional evidence, and updates claim status events.",
+      "Insurance gateway validates coverage, requests any extra evidence, and updates claim status events.",
       "Payments holds deposits or issues additional charges, while Booking updates renter visibility.",
       "Admin/Ops reviews the audit trail and coordinates resolution messaging to both parties.",
     ],
@@ -105,8 +105,8 @@ const concerns: Concern[] = [
   {
     title: "Privacy & compliance",
     items: [
-      "PII is isolated to a dedicated datastore with per-field encryption and strict access controls.",
-      "Right-to-access and right-to-be-forgotten workflows run asynchronously with review checkpoints.",
+      "PII lives in a dedicated datastore with per-field encryption and strict access controls.",
+      "Right-to-access and deletion workflows run asynchronously with human review checkpoints.",
       "Audit logs capture all sensitive actions, including admin overrides and payout adjustments.",
     ],
   },
@@ -114,7 +114,7 @@ const concerns: Concern[] = [
     title: "Platform enablement",
     items: [
       "Feature flags orchestrate gradual rollouts of new native capabilities.",
-      "Shared React Native component library enforces accessible typography, spacing, and color tokens.",
+      "Shared React Native components reinforce accessible typography, spacing, and color tokens.",
       "API schemas are versioned with contract tests to protect integrators and partner apps.",
     ],
   },
@@ -124,7 +124,7 @@ const dataHighlights = [
   {
     title: "Data domains",
     items: [
-      "Bookings, Availability, Listings, Messaging, Reviews, Payments, Insurance, and Identity services own their respective aggregates.",
+      "Bookings, Availability, Listings, Messaging, Reviews, Payments, Insurance, and Identity each own their core data sets.",
       "Cross-service references rely on immutable identifiers with lookup APIs rather than direct foreign keys.",
       "Analytics pipelines consume event streams and anonymized snapshots for decision-making.",
     ],
@@ -147,9 +147,9 @@ const Architecture = () => (
         <Text style={styles.overline}>System architecture</Text>
         <Text style={styles.title}>Service boundaries built for marketplace reliability</Text>
         <Text style={styles.subtitle}>
-          The Adventure Ready Rentals platform runs on a modular service ecosystem with React Native powering the
-          renter and owner experience across mobile and web. Each domain focuses on clear responsibilities while
-          sharing cross-cutting observability, privacy, and compliance tooling.
+          CiKr runs on a modular service ecosystem with React Native powering the renter and owner experience
+          across mobile and web. Each domain focuses on clear responsibilities, transparent money movement, and
+          reuse-friendly adventures while sharing observability, privacy, and compliance tooling.
         </Text>
       </View>
 

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -142,10 +142,10 @@ const Browse = () => {
       <Header />
       <ScrollView contentContainerStyle={styles.content}>
         <View style={styles.pageHeader}>
-          <Text style={styles.title}>Browse adventure gear</Text>
+          <Text style={styles.title}>Browse community gear near you</Text>
           <Text style={styles.subtitle}>
-            Seamlessly explore listings with components tuned for both tap-friendly native apps and responsive
-            web layouts.
+            Filter by location, dates, and categories to find trusted local gear with upfront fees, deposit
+            holds, and insurance details before you book.
           </Text>
         </View>
 
@@ -210,15 +210,17 @@ const Browse = () => {
         {showMap && (
           <View style={styles.mapPlaceholder}>
             <Text style={styles.mapPlaceholderText}>
-              Map preview coming soon. React Native keeps this component ready for both native and web
-              implementations.
+              Map preview coming soon. We’ll highlight nearby pickup points while keeping the experience
+              accessible on web and native.
             </Text>
           </View>
         )}
 
         <View style={styles.resultsHeader}>
           <Text style={styles.resultsCount}>{filteredGear.length} listings</Text>
-          <Text style={styles.resultsHint}>Tap a card to learn more and reserve through the native detail view.</Text>
+          <Text style={styles.resultsHint}>
+            Tap a card for transparent pricing, insurance choices, and pickup tips from the owner community.
+          </Text>
         </View>
 
         <View style={styles.grid}>

--- a/src/pages/HowItWorks.tsx
+++ b/src/pages/HowItWorks.tsx
@@ -6,48 +6,48 @@ import colors from "../theme/colors";
 
 const steps = [
   {
-    title: "Explore premium listings",
+    title: "Explore local listings",
     summary:
-      "Use the browse and filter tools to pinpoint the perfect equipment for your next outing.",
+      "Use filters to find gear lovingly maintained by nearby adventurers.",
     details: [
-      "Rich imagery, ratings, and pricing information render consistently across platforms.",
-      "React Query powers fast, cached data fetching for responsive list updates.",
+      "Compare daily rates, deposits, and insurance coverage at a glance.",
+      "Read friendly tips from owners about sizing, fit, and trail-ready accessories.",
     ],
   },
   {
-    title: "Reserve with confidence",
+    title: "Reserve with clarity",
     summary:
-      "Tap into a listing to view availability, insurance options, and owner requirements.",
+      "Lock in your dates knowing exactly how fees, deposits, and insurance support your trip.",
     details: [
-      "Interactive flows stay responsive thanks to shared React Native form logic.",
-      "Secure checkout integrates with the Payments service described in the architecture view.",
+      "Verification keeps the community safe while staying quick with reusable profile details.",
+      "Secure checkout confirms totals before you pay and emails every policy detail for easy reference.",
     ],
   },
   {
-    title: "Pick up and adventure",
-    summary: "Coordinated messaging ensures smooth hand-offs and dependable return experiences.",
+    title: "Pick up and go further",
+    summary: "Chat through pickup plans, snap a few photos, and start exploring with confidence.",
     details: [
-      "Owners manage bookings from the same React Native experience as renters.",
-      "Real-time updates keep both parties aligned on timing and condition reports.",
+      "Friendly reminders keep everyone aligned on pickup, return timing, and cleaning expectations.",
+      "If something happens, just upload photos within 48 hours—we’ll handle the rest.",
     ],
   },
 ];
 
 const highlights = [
   {
-    title: "Unified design system",
+    title: "Transparent from the first tap",
     description:
-      "Typography, spacing, and color tokens are shared between native and web builds, delivering a cohesive brand across every touchpoint.",
+      "Upfront totals outline service fees, deposits, and optional insurance so there are no surprises—just clear choices.",
   },
   {
-    title: "Offline ready",
+    title: "Built for friends planning trips",
     description:
-      "Critical screens cache data locally, allowing users to review details and prepare trips even when the signal drops in remote areas.",
+      "Guided checklists, reminders, and messaging keep renters and owners in sync without corporate jargon.",
   },
   {
-    title: "Accessibility first",
+    title: "Reuse over replace",
     description:
-      "Semantic roles, high contrast palettes, and large tap targets ensure the experience works for all explorers.",
+      "Sharing gear through CiKr keeps quality equipment in play longer, supports locals, and trims your footprint.",
   },
 ];
 
@@ -57,11 +57,10 @@ const HowItWorks = () => (
     <ScrollView contentContainerStyle={styles.content}>
       <View style={styles.hero}>
         <Text style={styles.overline}>How it works</Text>
-        <Text style={styles.title}>Plan adventures without swapping codebases</Text>
+        <Text style={styles.title}>Borrow gear safely in three easy steps</Text>
         <Text style={styles.subtitle}>
-          Adventure Ready Rentals now runs on a unified React Native foundation that renders beautifully on both
-          native and web platforms, helping teams iterate faster while customers enjoy a polished experience
-          everywhere.
+          CiKr combines a single React Native experience with friendly guidance so you can discover new trails,
+          understand every fee, and feel good about reusing gear that might otherwise sit idle.
         </Text>
       </View>
 

--- a/src/pages/InfoPage.tsx
+++ b/src/pages/InfoPage.tsx
@@ -21,40 +21,40 @@ type InfoPageContent = {
 
 const infoContent: Record<string, InfoPageContent> = {
   about: {
-    title: "About AdventureRent",
+    title: "About CiKr",
     intro:
-      "AdventureRent connects renters with trusted owners and partners so outdoor experiences are as easy to book as a city stay. Our marketplace is designed around transparent pricing, responsible stewardship, and Canadian-ready compliance from day one.",
+      "CiKr connects travellers with trusted local owners so you can borrow gear responsibly, support your community, and understand every fee before you book.",
     sections: [
       {
         heading: "What we believe",
         body: [
-          "We help people explore more while owning less. Listings, insurance, payments, and support are coordinated across the platform so every booking feels confident and fair for renters and owners alike.",
+          "We help friends explore more while buying less. Transparent pricing, optional insurance, and thoughtful messaging keep every booking fair, inclusive, and stress-free for renters and owners alike.",
         ],
       },
       {
         heading: "How we operate",
         body: [
-          "Our product spans modern web, mobile, and admin experiences backed by clearly scoped services—Identity, Listings, Search & Pricing, Booking, Payments & Payouts, Insurance, Messaging, Reviews, Admin/Ops, and Analytics. Each service enforces the right privacy and tax rules for Canada, including GST/PST handling and BC age-of-majority checks.",
+          "CiKr spans web, mobile, and admin tools backed by focused services—Identity, Listings, Search & Pricing, Booking, Payments & Payouts, Insurance, Messaging, Reviews, Admin/Ops, and Analytics. Each service honours Canadian privacy and tax rules, including GST/PST handling and BC age-of-majority checks.",
         ],
       },
     ],
   },
   safety: {
-    title: "Safety at AdventureRent",
+    title: "Safety at CiKr",
     intro:
-      "Every trip runs on layered trust controls spanning verification, insurance, messaging safeguards, and immutable audit logs.",
+      "Every trip runs on layered trust controls that combine verification, insurance, and easy reporting so you always know what to expect.",
     sections: [
       {
         heading: "What renters and owners can expect",
         body: [
-          "We verify users through OIDC with MFA options, age-of-majority checks, and KYC for payout eligibility. Bookings run through a refund policy engine with deposit pre-authorizations coordinated through Payments & Payouts.",
-          "An Insurance Gateway coordinates quotes, bindings, and claim evidence using signed URLs. Messaging threads and reviews feed light moderation signals routed to Admin/Ops for quick follow-up.",
+          "We verify users with secure sign-in, MFA options, age-of-majority checks, and KYC for payout eligibility. Booking requests clearly show deposit holds, refund windows, and insurance choices before you confirm.",
+          "Our Insurance Gateway coordinates quotes, binds coverage, and stores claim evidence through signed URLs. Messaging threads and reviews feed moderation signals routed to the CiKr team for fast follow-up.",
         ],
       },
       {
         heading: "Compliance",
         body: [
-          "We align with PIPEDA and BC PIPA, isolate personal information in a dedicated PII datastore, and maintain an append-only audit log for sensitive actions.",
+          "We align with PIPEDA and BC PIPA, isolate personal information in a dedicated datastore, and maintain an append-only audit log for sensitive actions.",
         ],
       },
     ],
@@ -62,18 +62,18 @@ const infoContent: Record<string, InfoPageContent> = {
   insurance: {
     title: "Insurance Overview",
     intro:
-      "We coordinate per-booking coverage so that approved trips include transparent protection and a clear claim path.",
+      "We coordinate per-booking coverage so approved trips include clear protection, optional add-ons, and a friendly claim path if something goes off-plan.",
     sections: [
       {
         heading: "Quotes & binding",
         body: [
-          "Insurance quotes surface alongside booking confirmations. Once confirmed, policies are bound through our Insurance Gateway using signed webhooks to keep status synchronized.",
+          "Insurance quotes appear alongside your booking confirmation. Once you accept, policies bind through our Insurance Gateway using signed webhooks so coverage status stays in sync.",
         ],
       },
       {
         heading: "Claims",
         body: [
-          "Claim intake supports structured evidence uploads to object storage with short-lived signed URLs. Status updates flow back through the gateway and notify the renter, owner, and Admin/Ops teams.",
+          "Claim intake supports structured evidence uploads with short-lived signed URLs. Status updates flow back through the gateway and notify the renter, owner, and CiKr support team.",
         ],
       },
     ],
@@ -81,12 +81,12 @@ const infoContent: Record<string, InfoPageContent> = {
   careers: {
     title: "Careers",
     intro:
-      "We are assembling a team passionate about outdoor access, reliability, and equitable marketplaces.",
+      "We’re building a team that believes outdoor access, transparency, and community care belong together.",
     sections: [
       {
         heading: "What we value",
         body: [
-          "Customer trust, clear ownership of services, privacy-first design, and resilience in every flow from booking to payout.",
+          "Customer trust, responsible reuse, privacy-first design, and resilience in every flow from booking to payout.",
         ],
         bullets: [
           "Product & Design focused on renter and owner journeys",
@@ -97,7 +97,7 @@ const infoContent: Record<string, InfoPageContent> = {
       {
         heading: "How to connect",
         body: [
-          "Email our team at careers@adventurerent.ca with a short note about the problems you love solving and the outdoor adventures that inspire you.",
+          "Email our team at careers@cikr.ca with a short note about the problems you love solving and the outdoor adventures that inspire you.",
         ],
       },
     ],
@@ -105,7 +105,7 @@ const infoContent: Record<string, InfoPageContent> = {
   "help-center": {
     title: "Help Center",
     intro:
-      "Need assistance? We publish how-to guides, policy explainers, and troubleshooting steps across the renter and owner lifecycle.",
+      "Need a hand? We publish step-by-step guides, policy explainers, and troubleshooting tips for every stage of the renter and owner journey.",
     sections: [
       {
         heading: "Popular topics",
@@ -116,7 +116,7 @@ const infoContent: Record<string, InfoPageContent> = {
           "Submitting insurance claims and providing evidence",
         ],
         body: [
-          "Still stuck? Reach out at support@adventurerent.ca and our Ops team will respond within one business day.",
+          "Still stuck? Reach out at support@cikr.ca and our friendly ops team will respond within one business day.",
         ],
       },
     ],
@@ -124,18 +124,18 @@ const infoContent: Record<string, InfoPageContent> = {
   "trust-and-safety": {
     title: "Trust & Safety",
     intro:
-      "We monitor the marketplace to keep experiences respectful, insured, and compliant with regional law.",
+      "We monitor the marketplace to keep every experience respectful, insured, and in line with regional laws.",
     sections: [
       {
         heading: "Our approach",
         body: [
-          "We run automated checks for suspicious behaviour, provide in-app reporting, and triage escalations through Admin/Ops. Messaging content adheres to retention limits and can be exported or erased per PIPEDA guidelines.",
+          "Automated checks flag suspicious behaviour, in-app reporting makes it easy to speak up, and our team triages escalations quickly. Messaging content follows retention limits and can be exported or erased under PIPEDA guidelines.",
         ],
       },
       {
         heading: "Report a concern",
         body: [
-          "Email trust@adventurerent.ca or flag content directly in messaging threads. Critical incidents trigger break-glass workflows with full audit trails.",
+          "Email trust@cikr.ca or flag content directly in messaging threads. Critical incidents trigger break-glass workflows with full audit trails.",
         ],
       },
     ],
@@ -143,19 +143,19 @@ const infoContent: Record<string, InfoPageContent> = {
   terms: {
     title: "Terms of Service",
     intro:
-      "By using AdventureRent you agree to these marketplace terms. We keep them concise so you understand your responsibilities before listing or booking gear.",
+      "By using CiKr you agree to these marketplace terms. We keep them clear so you understand responsibilities before listing or booking gear.",
     lastUpdated: "Updated February 2025",
     sections: [
       {
         heading: "Key points",
         bullets: [
           "Renters must be at least 19 years old in BC and maintain valid payment methods for deposit holds.",
-          "Owners and partners confirm they have rights to list gear and will keep listings accurate and safe.",
+          "Owners and partners confirm they have rights to list gear and will keep listings accurate, safe, and ready for reuse.",
           "Fees, GST, and PST are disclosed before checkout; payment captures and refunds run through our Payments & Payouts service.",
           "Insurance claims must follow evidence and timelines shared during claim intake.",
         ],
         body: [
-          "Breaking these terms may result in suspension or withheld payouts per our trust and compliance policies.",
+          "Breaking these terms may result in suspension or withheld payouts under our trust and compliance policies.",
         ],
       },
     ],
@@ -163,12 +163,12 @@ const infoContent: Record<string, InfoPageContent> = {
   privacy: {
     title: "Privacy Policy",
     intro:
-      "We take privacy seriously by isolating personal data, limiting retention, and providing full export and deletion workflows.",
+      "We take privacy seriously by isolating personal data, limiting retention, and offering simple ways to review or remove your information.",
     sections: [
       {
         heading: "Data handling",
         body: [
-          "Identity and PII data are stored in dedicated services with column-level encryption. Operational data that references PII uses scoped identifiers only.",
+          "Identity and PII data live in dedicated services with column-level encryption. Operational data that references PII uses scoped identifiers only.",
         ],
       },
       {

--- a/src/pages/ListGear.tsx
+++ b/src/pages/ListGear.tsx
@@ -23,10 +23,10 @@ const ListGear = () => {
       <ScrollView contentContainerStyle={styles.content}>
         <View style={styles.hero}>
           <Text style={styles.overline}>List your gear</Text>
-          <Text style={styles.title}>Share trusted equipment with the community</Text>
+          <Text style={styles.title}>Share your trusted gear with the CiKr community</Text>
           <Text style={styles.subtitle}>
-            Our React Native-powered onboarding guides you through compliant, high-converting listings that
-            look fantastic on every screen.
+            Our guided steps make it simple to outline pricing, deposits, insurance, and care expectations so
+            every renter feels welcome and informed.
           </Text>
         </View>
 
@@ -81,32 +81,32 @@ const ListGear = () => {
             <Text style={styles.submitText}>Preview listing</Text>
           </Pressable>
           <Text style={styles.formHint}>
-            Publishing connects your listing to pricing, insurance, and payout workflows orchestrated by the
-            services outlined in our architecture overview.
+            Publishing shares your listing with renters alongside transparent fees, insurance coverage, and
+            payout timelines handled by CiKr’s services.
           </Text>
         </View>
 
         <View style={styles.tipsSection}>
           <Text style={styles.sectionTitle}>Owner success tips</Text>
           <View style={styles.tipCard}>
-            <Text style={styles.tipTitle}>Capture stunning photography</Text>
+            <Text style={styles.tipTitle}>Show the gear in action</Text>
             <Text style={styles.tipDescription}>
-              High-resolution images increase conversion across mobile and desktop. Showcase condition, key
-              accessories, and the gear in action.
+              Bright, inclusive photos help friends picture themselves using your gear and highlight any
+              safety add-ons that are included.
             </Text>
           </View>
           <View style={styles.tipCard}>
-            <Text style={styles.tipTitle}>Set transparent expectations</Text>
+            <Text style={styles.tipTitle}>Be upfront about fees and care</Text>
             <Text style={styles.tipDescription}>
-              Outline pickup windows, return requirements, and cleaning standards so renters feel confident before
-              they book.
+              Share deposit amounts, cleaning expectations, and eco-friendly care tips so renters return items
+              in great shape.
             </Text>
           </View>
           <View style={styles.tipCard}>
             <Text style={styles.tipTitle}>Keep availability current</Text>
             <Text style={styles.tipDescription}>
-              Sync calendars frequently—our React Native experience makes managing schedules quick wherever you
-              are.
+              Update your calendar often—CiKr sends friendly nudges and syncs across devices to keep bookings
+              smooth.
             </Text>
           </View>
         </View>

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -14,9 +14,10 @@ const NotFound = () => {
       <ScrollView contentContainerStyle={styles.content}>
         <View style={styles.messageBlock}>
           <Text style={styles.code}>404</Text>
-          <Text style={styles.title}>This trail seems to be unmarked</Text>
+          <Text style={styles.title}>Looks like this trail isn’t marked yet</Text>
           <Text style={styles.subtitle}>
-            The page you requested doesn’t exist. Use the controls below to return to familiar terrain.
+            The page you’re seeking is still being charted. Head back home to discover gear, safety tips, and
+            locals ready to help plan your next outing.
           </Text>
           <Pressable
             accessibilityRole="button"

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -27,12 +27,12 @@ const SignIn = () => {
           <Text style={styles.overline}>{isSignIn ? "Welcome back" : "Join the community"}</Text>
           <Text style={styles.title}>
             {isSignIn
-              ? "Access your adventure hub"
-              : "Create an account in minutes"}
+              ? "Sign in to keep exploring safely"
+              : "Create your CiKr account in minutes"}
           </Text>
           <Text style={styles.subtitle}>
-            The authentication flow shares a single React Native implementation across mobile and web, including
-            validation states and secure text entry.
+            We keep things friendly and secure—let’s get you verified so you can start renting safely, review
+            deposits, and choose insurance with confidence.
           </Text>
         </View>
 
@@ -117,8 +117,8 @@ const SignIn = () => {
             <Text style={styles.submitText}>{isSignIn ? "Sign in" : "Create account"}</Text>
           </Pressable>
           <Text style={styles.legal}>
-            By continuing you agree to our Terms of Service and confirm the privacy-first practices outlined in
-            the architecture documentation.
+            By continuing you agree to our Terms of Service and acknowledge our privacy-first practices that
+            protect your personal information.
           </Text>
         </View>
 


### PR DESCRIPTION
## Summary
- rename the app to CiKr across metadata, routing chrome, and shared layout text so the brand reflects trustworthy, eco-minded gear sharing
- refresh home, browse, and list-your-gear narratives to emphasise transparent pricing, insurance, and inclusive community action
- update informational pages and sign-in flows with friendly guidance and sustainable messaging consistent with the new tone of voice

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68cc735e526c8325b0ff8dedb6376bb2