### PR TITLE
feat: load gear listings from firestore

### DIFF
--- a/src/components/FeaturedGear.tsx
+++ b/src/components/FeaturedGear.tsx
@@ -1,67 +1,37 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
 import GearCard from "./GearCard";
-import climbingGear from "@/assets/climbing-gear.jpg";
-import campingGear from "@/assets/camping-gear.jpg";
-import waterSportsGear from "@/assets/water-sports-gear.jpg";
-import winterSportsGear from "@/assets/winter-sports-gear.jpg";
+import { getFeaturedEquipment, type EquipmentRecord } from "@/services/firestore";
+import { normalizeEquipmentToGearCard } from "@/utils/gear";
 
-const featuredGear = [
-  {
-    title: "Professional Climbing Rope Set",
-    description: "Complete dynamic climbing rope with carabiners and safety gear included",
-    image: climbingGear,
-    price: 45,
-    rating: 4.9,
-    reviewCount: 127,
-    location: "Boulder, CO"
-  },
-  {
-    title: "4-Person Family Camping Kit",
-    description: "Everything you need for family camping: tent, sleeping bags, camp chairs",
-    image: campingGear,
-    price: 85,
-    rating: 4.8,
-    reviewCount: 89,
-    location: "Portland, OR"
-  },
-  {
-    title: "Inflatable Kayak with Paddle",
-    description: "2-person inflatable kayak perfect for lakes and calm rivers",
-    image: waterSportsGear,
-    price: 65,
-    rating: 4.7,
-    reviewCount: 156,
-    location: "Lake Tahoe, CA"
-  },
-  {
-    title: "Premium Ski Equipment Set",
-    description: "High-performance skis, boots, and poles for advanced skiers",
-    image: winterSportsGear,
-    price: 120,
-    rating: 4.9,
-    reviewCount: 94,
-    location: "Aspen, CO"
-  },
-  {
-    title: "Rock Climbing Starter Kit",
-    description: "Perfect for beginners: harness, helmet, shoes, and chalk bag",
-    image: climbingGear,
-    price: 35,
-    rating: 4.6,
-    reviewCount: 203,
-    location: "Joshua Tree, CA"
-  },
-  {
-    title: "Backpacking Essentials",
-    description: "Lightweight tent, sleeping system, and cooking gear for multi-day hikes",
-    image: campingGear,
-    price: 95,
-    rating: 4.8,
-    reviewCount: 167,
-    location: "Yosemite, CA"
-  }
-];
+type FeaturedGearProps = {
+  equipment?: EquipmentRecord[];
+};
 
-const FeaturedGear = () => {
+const FeaturedGear = ({ equipment }: FeaturedGearProps) => {
+  const {
+    data: featuredEquipment,
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: ["equipment", "featured"],
+    queryFn: getFeaturedEquipment,
+    enabled: !equipment,
+  });
+
+  const gearItems = useMemo(() => {
+    const currentEquipment = equipment ?? featuredEquipment ?? [];
+
+    if (currentEquipment.length === 0) {
+      return [];
+    }
+
+    return currentEquipment
+      .map(normalizeEquipmentToGearCard)
+      .sort((a, b) => b.rating - a.rating)
+      .slice(0, 6);
+  }, [equipment, featuredEquipment]);
+
   return (
     <section className="py-16">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -73,20 +43,32 @@ const FeaturedGear = () => {
             Hand-picked adventure equipment from trusted local owners near you.
           </p>
         </div>
-        
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {featuredGear.map((gear, index) => (
-            <GearCard
-              key={index}
-              title={gear.title}
-              description={gear.description}
-              image={gear.image}
-              price={gear.price}
-              rating={gear.rating}
-              reviewCount={gear.reviewCount}
-              location={gear.location}
-            />
-          ))}
+
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {isLoading ? (
+            <div className="col-span-full text-center text-muted-foreground">Loading featured gear...</div>
+          ) : isError ? (
+            <div className="col-span-full rounded-lg border border-destructive/50 bg-destructive/10 p-6 text-center text-destructive">
+              We couldn't load featured gear at the moment. Please check back later.
+            </div>
+          ) : gearItems.length === 0 ? (
+            <div className="col-span-full rounded-lg border border-border bg-muted/40 p-6 text-center text-muted-foreground">
+              Gear listings will appear here as soon as items are available.
+            </div>
+          ) : (
+            gearItems.map((gear) => (
+              <GearCard
+                key={gear.id}
+                title={gear.title}
+                description={gear.description}
+                image={gear.image}
+                price={gear.price}
+                rating={gear.rating}
+                reviewCount={gear.reviewCount}
+                location={gear.location}
+              />
+            ))
+          )}
         </div>
       </div>
     </section>

--- a/src/services/firestore.ts
+++ b/src/services/firestore.ts
@@ -1,4 +1,16 @@
-import { doc, getDoc, serverTimestamp, setDoc, Timestamp } from "firebase/firestore";
+import {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  query,
+  serverTimestamp,
+  setDoc,
+  Timestamp,
+  where,
+  type DocumentData,
+  type QueryDocumentSnapshot,
+} from "firebase/firestore";
 
 import { db } from "@/lib/firebase";
 
@@ -13,6 +25,58 @@ export type UserProfile = {
 };
 
 export type CreateUserProfile = Omit<UserProfile, "id" | "createdAt" | "updatedAt">;
+
+export type EquipmentRecord = {
+  id: string;
+  title: string;
+  description: string;
+  pricePerDay: number;
+  rating: number;
+  reviewCount: number;
+  location: string;
+  imageUrls: string[];
+  category?: string;
+};
+
+const getNumericValue = (value: unknown): number => {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : 0;
+  }
+
+  if (typeof value === "string") {
+    const parsed = Number.parseFloat(value);
+
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+
+  return 0;
+};
+
+const mapEquipmentSnapshot = (
+  snapshot: QueryDocumentSnapshot<DocumentData>,
+): EquipmentRecord => {
+  const data = snapshot.data();
+
+  const ratingValue = getNumericValue(data.rating ?? data.averageRating);
+  const reviewCountValue = Math.max(0, Math.trunc(getNumericValue(data.reviewCount ?? data.reviews)));
+  const rawCategory = typeof data.category === "string" ? data.category.trim() : undefined;
+
+  const imageUrls = Array.isArray(data.imageUrls)
+    ? data.imageUrls.filter((url): url is string => typeof url === "string" && url.length > 0)
+    : [];
+
+  return {
+    id: snapshot.id,
+    title: typeof data.title === "string" ? data.title : "",
+    description: typeof data.description === "string" ? data.description : "",
+    pricePerDay: getNumericValue(data.pricePerDay ?? data.price ?? data.dailyRate),
+    rating: ratingValue > 0 ? ratingValue : 0,
+    reviewCount: Number.isFinite(reviewCountValue) ? reviewCountValue : 0,
+    location: typeof data.location === "string" ? data.location : "",
+    imageUrls,
+    category: rawCategory ? rawCategory.toLowerCase() : undefined,
+  };
+};
 
 export const addUser = async (uid: string, data: CreateUserProfile) => {
   const userRef = doc(db, "users", uid);
@@ -42,4 +106,29 @@ export const getUser = async (uid: string): Promise<UserProfile | null> => {
     id: snapshot.id,
     ...data,
   };
+};
+
+export const getEquipmentList = async (): Promise<EquipmentRecord[]> => {
+  const snapshot = await getDocs(collection(db, "equipment"));
+
+  return snapshot.docs.map(mapEquipmentSnapshot);
+};
+
+export const getFeaturedEquipment = async (): Promise<EquipmentRecord[]> => {
+  const equipmentRef = collection(db, "equipment");
+
+  const featuredFields = ["isFeatured", "featured"] as const;
+
+  for (const field of featuredFields) {
+    const featuredQuery = query(equipmentRef, where(field, "==", true));
+    const snapshot = await getDocs(featuredQuery);
+
+    if (!snapshot.empty) {
+      return snapshot.docs.map(mapEquipmentSnapshot);
+    }
+  }
+
+  const equipment = await getEquipmentList();
+
+  return equipment.slice(0, 6);
 };

--- a/src/utils/gear.ts
+++ b/src/utils/gear.ts
@@ -1,0 +1,30 @@
+import placeholderImage from "@/assets/hero-adventure-gear.jpg";
+import type { EquipmentRecord } from "@/services/firestore";
+
+export type GearCardData = {
+  id: string;
+  title: string;
+  description: string;
+  image: string;
+  price: number;
+  rating: number;
+  reviewCount: number;
+  location: string;
+  category?: string;
+};
+
+export const normalizeEquipmentToGearCard = (
+  equipment: EquipmentRecord,
+): GearCardData => {
+  return {
+    id: equipment.id,
+    title: equipment.title || "Untitled gear",
+    description: equipment.description || "",
+    image: equipment.imageUrls?.[0] ?? placeholderImage,
+    price: Number.isFinite(equipment.pricePerDay) ? equipment.pricePerDay : 0,
+    rating: Number.isFinite(equipment.rating) ? equipment.rating : 0,
+    reviewCount: Number.isFinite(equipment.reviewCount) ? equipment.reviewCount : 0,
+    location: equipment.location || "Unknown location",
+    category: equipment.category ?? undefined,
+  };
+};


### PR DESCRIPTION
## Summary
- add Firestore queries to fetch equipment and featured gear
- consume dynamic gear listings on the browse and featured sections with loading/error states
- share a normalization helper so GearCard receives consistent props

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cca398c834832586c6ec112ba6d92e