### PR TITLE
feat: enable gear listing submissions

### DIFF
--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,6 +1,7 @@
 import { FirebaseOptions, getApp, getApps, initializeApp } from "firebase/app";
 import { getAuth } from "firebase/auth";
 import { getFirestore } from "firebase/firestore";
+import { getStorage } from "firebase/storage";
 
 const firebaseConfig: FirebaseOptions = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY ?? "",
@@ -16,5 +17,6 @@ const app = getApps().length > 0 ? getApp() : initializeApp(firebaseConfig);
 
 const auth = getAuth(app);
 const db = getFirestore(app);
+const storage = getStorage(app);
 
-export { app, auth, db };
+export { app, auth, db, storage };

--- a/src/pages/ListGear.tsx
+++ b/src/pages/ListGear.tsx
@@ -1,11 +1,21 @@
-import { useEffect, useMemo, useState, type ChangeEvent } from "react";
-import { Camera, DollarSign, MapPin, Calendar, Shield, Users } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Camera, DollarSign, MapPin, Calendar, Shield, Users, Loader2 } from "lucide-react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { useMutation } from "@tanstack/react-query";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Progress } from "@/components/ui/progress";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { toast } from "@/components/ui/use-toast";
+import { addEquipment, uploadGearImages } from "@/services/firestore";
+import { useAuth } from "@/contexts/AuthContext";
 
 const earnings = [
   { gear: "Climbing Rope Set", monthly: "$450" },
@@ -14,10 +24,76 @@ const earnings = [
   { gear: "Ski Equipment", monthly: "$890" }
 ];
 
-const ListGear = () => {
-  const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+const categoryOptions = [
+  "Climbing & Mountaineering",
+  "Camping & Hiking",
+  "Water Sports",
+  "Winter Sports",
+  "Other",
+];
 
-  const previewUrls = useMemo(() => selectedFiles.map((file) => ({ file, url: URL.createObjectURL(file) })), [selectedFiles]);
+const formSchema = z.object({
+  title: z.string().trim().min(1, "Please enter a title."),
+  category: z.string().trim().min(1, "Please choose a category."),
+  description: z.string().trim().min(1, "Please provide a description."),
+  pricePerDay: z
+    .string({ required_error: "Daily rate is required." })
+    .trim()
+    .refine((value) => {
+      const numeric = Number.parseFloat(value);
+
+      return Number.isFinite(numeric) && numeric > 0;
+    }, "Daily rate must be a valid number greater than zero."),
+  weeklyRate: z
+    .string()
+    .trim()
+    .optional()
+    .refine((value) => {
+      if (!value) {
+        return true;
+      }
+
+      const numeric = Number.parseFloat(value);
+
+      return Number.isFinite(numeric) && numeric > 0;
+    }, "Weekly rate must be a valid number greater than zero."),
+  location: z.string().trim().min(1, "Please provide a location."),
+  availabilityNote: z.string().trim().optional(),
+  photos: z.array(z.instanceof(File)).min(1, "Please upload at least one photo."),
+});
+
+type GearFormValues = z.infer<typeof formSchema>;
+
+const defaultValues: GearFormValues = {
+  title: "",
+  category: "",
+  description: "",
+  pricePerDay: "",
+  weeklyRate: "",
+  location: "",
+  availabilityNote: "",
+  photos: [],
+};
+
+const buildFileKey = (file: File) => `${file.name}-${file.lastModified}`;
+
+const ListGear = () => {
+  const { user, loading: authLoading } = useAuth();
+  const [uploadProgress, setUploadProgress] = useState<Record<string, number>>({});
+  const [submissionError, setSubmissionError] = useState<string | null>(null);
+
+  const form = useForm<GearFormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues,
+  });
+
+  const photoFiles = form.watch("photos");
+
+  const previewUrls = useMemo(() => {
+    const files = photoFiles ?? [];
+
+    return files.map((file) => ({ file, url: URL.createObjectURL(file) }));
+  }, [photoFiles]);
 
   useEffect(() => {
     return () => {
@@ -25,10 +101,82 @@ const ListGear = () => {
     };
   }, [previewUrls]);
 
-  const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const files = event.target.files ? Array.from(event.target.files) : [];
-    setSelectedFiles(files);
+  const mutation = useMutation({
+    mutationFn: async (values: GearFormValues) => {
+      if (!user) {
+        throw new Error("You must be signed in to list your gear.");
+      }
+
+      values.photos.forEach((file) => {
+        const key = buildFileKey(file);
+        setUploadProgress((prev) => ({ ...prev, [key]: 0 }));
+      });
+
+      const dailyRate = Number.parseFloat(values.pricePerDay);
+      const weeklyRateValue = values.weeklyRate ? Number.parseFloat(values.weeklyRate) : undefined;
+      const availabilityNote = values.availabilityNote?.trim();
+
+      const imageUrls = await uploadGearImages({
+        files: values.photos,
+        ownerId: user.uid,
+        onProgress: ({ file, progress }) => {
+          const key = buildFileKey(file);
+          setUploadProgress((prev) => ({ ...prev, [key]: progress }));
+        },
+      });
+
+      const trimmedCategory = values.category.trim();
+
+      await addEquipment({
+        title: values.title.trim(),
+        description: values.description.trim(),
+        category: trimmedCategory,
+        pricePerDay: dailyRate,
+        ownerId: user.uid,
+        imageUrls,
+        location: values.location.trim(),
+        availability: true,
+        weeklyRate: weeklyRateValue,
+        availabilityNote: availabilityNote && availabilityNote.length > 0 ? availabilityNote : undefined,
+      });
+    },
+    onSuccess: () => {
+      toast({
+        title: "Your gear is listed!",
+        description: "We published your listing and saved your gear photos.",
+      });
+      setSubmissionError(null);
+      setUploadProgress({});
+      form.reset({ ...defaultValues, photos: [] });
+    },
+    onError: (error) => {
+      const message = error instanceof Error ? error.message : "We couldn't list your gear. Please try again.";
+      setSubmissionError(message);
+      toast({
+        title: "Unable to list gear",
+        description: message,
+        variant: "destructive",
+      });
+    },
+  });
+
+  const handleSubmitForm = async (values: GearFormValues) => {
+    if (!user) {
+      return;
+    }
+
+    setSubmissionError(null);
+    setUploadProgress({});
+
+    try {
+      await mutation.mutateAsync(values);
+    } catch (error) {
+      console.error("Failed to submit gear listing:", error);
+    }
   };
+
+  const isSubmitting = mutation.isPending;
+  const canSubmit = !!user && !authLoading && !isSubmitting;
 
   return (
     <div className="min-h-screen bg-background">
@@ -107,145 +255,263 @@ const ListGear = () => {
                   Fill out the details below to start earning from your adventure gear
                 </p>
               </CardHeader>
-              <CardContent className="space-y-6">
-                {/* Basic Info */}
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                  <div>
-                    <label className="block text-sm font-medium text-foreground mb-2">
-                      Gear Title *
-                    </label>
-                    <Input placeholder="e.g., Professional Climbing Rope Set" />
-                  </div>
-                  <div>
-                    <label className="block text-sm font-medium text-foreground mb-2">
-                      Category *
-                    </label>
-                    <select className="w-full h-11 px-3 rounded-xl border border-border bg-background">
-                      <option>Select category</option>
-                      <option>Climbing & Mountaineering</option>
-                      <option>Camping & Hiking</option>
-                      <option>Water Sports</option>
-                      <option>Winter Sports</option>
-                      <option>Other</option>
-                    </select>
-                  </div>
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium text-foreground mb-2">
-                    Description *
-                  </label>
-                  <Textarea 
-                    placeholder="Describe your gear, its condition, what's included, and any special features..."
-                    rows={4}
-                  />
-                </div>
-
-                {/* Pricing */}
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                  <div>
-                    <label className="block text-sm font-medium text-foreground mb-2">
-                      Daily Rate *
-                    </label>
-                    <div className="relative">
-                      <DollarSign className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4" />
-                      <Input placeholder="45" className="pl-10" />
-                    </div>
-                  </div>
-                  <div>
-                    <label className="block text-sm font-medium text-foreground mb-2">
-                      Weekly Rate (optional)
-                    </label>
-                    <div className="relative">
-                      <DollarSign className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4" />
-                      <Input placeholder="250" className="pl-10" />
-                    </div>
-                  </div>
-                </div>
-
-                {/* Location */}
-                <div>
-                  <label className="block text-sm font-medium text-foreground mb-2">
-                    Location *
-                  </label>
-                  <div className="relative">
-                    <MapPin className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4" />
-                    <Input placeholder="City, State" className="pl-10" />
-                  </div>
-                </div>
-
-                {/* Photos */}
-                <div>
-                  <label className="block text-sm font-medium text-foreground mb-2">
-                    Photos *
-                  </label>
-                  <div className="border-2 border-dashed border-border rounded-xl p-8 text-center">
-                    <Camera className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
-                    <div className="text-foreground font-medium mb-2">
-                      Upload photos of your gear
-                    </div>
-                    <div className="text-sm text-muted-foreground mb-4">
-                      Add at least 3 high-quality photos showing different angles
-                    </div>
-                    <input
-                      id="gear-photos"
-                      type="file"
-                      accept="image/*"
-                      multiple
-                      className="sr-only"
-                      onChange={handleFileChange}
-                    />
-                    <Button variant="outline" asChild>
-                      <label htmlFor="gear-photos" className="cursor-pointer">
-                        Choose Files
-                      </label>
-                    </Button>
-                    {selectedFiles.length > 0 && (
-                      <div className="mt-6 text-left">
-                        <p className="text-sm font-medium text-foreground">
-                          {selectedFiles.length} file{selectedFiles.length === 1 ? "" : "s"} selected
-                        </p>
-                        <div className="mt-4 grid gap-4 sm:grid-cols-2">
-                          {previewUrls.map(({ file, url }) => (
-                            <div
-                              key={`${file.name}-${file.lastModified}`}
-                              className="flex items-center gap-3 rounded-lg border border-border bg-background/60 p-3"
-                            >
-                              <img
-                                src={url}
-                                alt={file.name}
-                                className="h-14 w-14 flex-none rounded-md object-cover"
-                              />
-                              <div>
-                                <p className="text-sm font-medium text-foreground truncate" title={file.name}>
-                                  {file.name}
-                                </p>
-                                <p className="text-xs text-muted-foreground">
-                                  {(file.size / 1024 / 1024).toFixed(2)} MB
-                                </p>
-                              </div>
-                            </div>
-                          ))}
-                        </div>
-                      </div>
+              <CardContent>
+                <Form {...form}>
+                  <form onSubmit={form.handleSubmit(handleSubmitForm)} className="space-y-6">
+                    {!authLoading && !user && (
+                      <Alert>
+                        <AlertTitle>Sign in to list your gear</AlertTitle>
+                        <AlertDescription>
+                          Create or sign in to your account so we can publish your listing under your owner profile.
+                        </AlertDescription>
+                      </Alert>
                     )}
-                  </div>
-                </div>
 
-                {/* Availability */}
-                <div>
-                  <label className="block text-sm font-medium text-foreground mb-2">
-                    Availability
-                  </label>
-                  <div className="relative">
-                    <Calendar className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4" />
-                    <Input placeholder="Select available dates" className="pl-10" />
-                  </div>
-                </div>
+                    {submissionError && (
+                      <Alert variant="destructive">
+                        <AlertTitle>Unable to list gear</AlertTitle>
+                        <AlertDescription>{submissionError}</AlertDescription>
+                      </Alert>
+                    )}
 
-                <Button variant="action" size="lg" className="w-full">
-                  List My Gear
-                </Button>
+                    <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                      <FormField
+                        control={form.control}
+                        name="title"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>Gear Title *</FormLabel>
+                            <FormControl>
+                              <Input placeholder="e.g., Professional Climbing Rope Set" {...field} />
+                            </FormControl>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                      <FormField
+                        control={form.control}
+                        name="category"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>Category *</FormLabel>
+                            <FormControl>
+                              <select
+                                className="w-full h-11 rounded-xl border border-border bg-background px-3"
+                                {...field}
+                              >
+                                <option value="">Select category</option>
+                                {categoryOptions.map((option) => (
+                                  <option key={option} value={option}>
+                                    {option}
+                                  </option>
+                                ))}
+                              </select>
+                            </FormControl>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                    </div>
+
+                    <FormField
+                      control={form.control}
+                      name="description"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Description *</FormLabel>
+                          <FormControl>
+                            <Textarea
+                              placeholder="Describe your gear, its condition, what's included, and any special features..."
+                              rows={4}
+                              {...field}
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+
+                    <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                      <FormField
+                        control={form.control}
+                        name="pricePerDay"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>Daily Rate *</FormLabel>
+                            <FormControl>
+                              <div className="relative">
+                                <DollarSign className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 transform text-muted-foreground" />
+                                <Input
+                                  type="number"
+                                  inputMode="decimal"
+                                  step="0.01"
+                                  min="0"
+                                  placeholder="45"
+                                  className="pl-10"
+                                  {...field}
+                                />
+                              </div>
+                            </FormControl>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                      <FormField
+                        control={form.control}
+                        name="weeklyRate"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>Weekly Rate (optional)</FormLabel>
+                            <FormControl>
+                              <div className="relative">
+                                <DollarSign className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 transform text-muted-foreground" />
+                                <Input
+                                  type="number"
+                                  inputMode="decimal"
+                                  step="0.01"
+                                  min="0"
+                                  placeholder="250"
+                                  className="pl-10"
+                                  {...field}
+                                />
+                              </div>
+                            </FormControl>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                    </div>
+
+                    <FormField
+                      control={form.control}
+                      name="location"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Location *</FormLabel>
+                          <FormControl>
+                            <div className="relative">
+                              <MapPin className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 transform text-muted-foreground" />
+                              <Input placeholder="City, State" className="pl-10" {...field} />
+                            </div>
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+
+                    <FormField
+                      control={form.control}
+                      name="photos"
+                      render={({ field }) => {
+                        const files = field.value ?? [];
+
+                        return (
+                          <FormItem>
+                            <FormLabel>Photos *</FormLabel>
+                            <div className="border-2 border-dashed border-border rounded-xl p-8 text-center">
+                              <Camera className="mx-auto mb-4 h-12 w-12 text-muted-foreground" />
+                              <div className="text-foreground font-medium mb-2">Upload photos of your gear</div>
+                              <div className="text-sm text-muted-foreground mb-4">
+                                Add at least 3 high-quality photos showing different angles
+                              </div>
+                              <FormControl>
+                                <input
+                                  id="gear-photos"
+                                  type="file"
+                                  accept="image/*"
+                                  multiple
+                                  className="sr-only"
+                                  onChange={(event) => {
+                                    const list = event.target.files ? Array.from(event.target.files) : [];
+                                    field.onChange(list);
+                                    field.onBlur();
+                                    if (list.length > 0) {
+                                      form.clearErrors("photos");
+                                    }
+                                    // Allow re-selecting the same file name by resetting the input
+                                    event.target.value = "";
+                                  }}
+                                />
+                              </FormControl>
+                              <Button variant="outline" asChild disabled={isSubmitting}>
+                                <label htmlFor="gear-photos" className="cursor-pointer">
+                                  Choose Files
+                                </label>
+                              </Button>
+                              {files.length > 0 && (
+                                <div className="mt-6 text-left">
+                                  <p className="text-sm font-medium text-foreground">
+                                    {files.length} file{files.length === 1 ? "" : "s"} selected
+                                  </p>
+                                  <div className="mt-4 grid gap-4 sm:grid-cols-2">
+                                    {previewUrls.map(({ file, url }) => {
+                                      const key = buildFileKey(file);
+                                      const progress = uploadProgress[key];
+
+                                      return (
+                                        <div
+                                          key={key}
+                                          className="flex items-center gap-3 rounded-lg border border-border bg-background/60 p-3"
+                                        >
+                                          <img src={url} alt={file.name} className="h-14 w-14 flex-none rounded-md object-cover" />
+                                          <div className="min-w-0 flex-1">
+                                            <p className="truncate text-sm font-medium text-foreground" title={file.name}>
+                                              {file.name}
+                                            </p>
+                                            <p className="text-xs text-muted-foreground">
+                                              {(file.size / 1024 / 1024).toFixed(2)} MB
+                                            </p>
+                                            {isSubmitting && typeof progress === "number" && progress >= 0 && (
+                                              <div className="mt-2 space-y-1">
+                                                <Progress value={progress} className="h-2" />
+                                                <p className="text-xs text-muted-foreground">
+                                                  {Math.round(progress)}% uploaded
+                                                </p>
+                                              </div>
+                                            )}
+                                          </div>
+                                        </div>
+                                      );
+                                    })}
+                                  </div>
+                                </div>
+                              )}
+                            </div>
+                            <FormMessage />
+                          </FormItem>
+                        );
+                      }}
+                    />
+
+                    <FormField
+                      control={form.control}
+                      name="availabilityNote"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Availability</FormLabel>
+                          <FormControl>
+                            <div className="relative">
+                              <Calendar className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 transform text-muted-foreground" />
+                              <Input placeholder="Select available dates" className="pl-10" {...field} />
+                            </div>
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+
+                    <Button variant="action" size="lg" className="w-full" type="submit" disabled={!canSubmit}>
+                      {isSubmitting ? (
+                        <span className="flex items-center justify-center gap-2">
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                          Listing your gear...
+                        </span>
+                      ) : (
+                        "List My Gear"
+                      )}
+                    </Button>
+                  </form>
+                </Form>
               </CardContent>
             </Card>
           </div>


### PR DESCRIPTION
## Summary
- export Firebase Storage and add Firestore helpers for creating equipment listings with uploaded images
- rebuild the List Gear page around react-hook-form and a React Query mutation that uploads photos before saving the listing
- surface inline authentication/validation messaging, upload progress, and success toasts while resetting the form after submission

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cca550c4e8832580a4d63558e02758