### PR TITLE
Add ThemeProvider to application root

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { AuthProvider } from "@/contexts/AuthContext";
+import { ThemeProvider } from "next-themes";
 import Index from "./pages/Index";
 import Browse from "./pages/Browse";
 import HowItWorks from "./pages/HowItWorks";
@@ -17,25 +18,27 @@ const queryClient = new QueryClient();
 
 const App = () => (
   <QueryClientProvider client={queryClient}>
-    <TooltipProvider>
-      <Toaster />
-      <Sonner />
-      <AuthProvider>
-        <BrowserRouter>
-          <Routes>
-            <Route path="/" element={<Index />} />
-            <Route path="/browse" element={<Browse />} />
-            <Route path="/how-it-works" element={<HowItWorks />} />
-            <Route path="/list-gear" element={<ListGear />} />
-            <Route path="/signin" element={<SignIn />} />
-            <Route path="/architecture" element={<Architecture />} />
-            <Route path="/info/:slug" element={<InfoPage />} />
-            {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-            <Route path="*" element={<NotFound />} />
-          </Routes>
-        </BrowserRouter>
-      </AuthProvider>
-    </TooltipProvider>
+    <ThemeProvider attribute="class" defaultTheme="system">
+      <TooltipProvider>
+        <Toaster />
+        <Sonner />
+        <AuthProvider>
+          <BrowserRouter>
+            <Routes>
+              <Route path="/" element={<Index />} />
+              <Route path="/browse" element={<Browse />} />
+              <Route path="/how-it-works" element={<HowItWorks />} />
+              <Route path="/list-gear" element={<ListGear />} />
+              <Route path="/signin" element={<SignIn />} />
+              <Route path="/architecture" element={<Architecture />} />
+              <Route path="/info/:slug" element={<InfoPage />} />
+              {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+              <Route path="*" element={<NotFound />} />
+            </Routes>
+          </BrowserRouter>
+        </AuthProvider>
+      </TooltipProvider>
+    </ThemeProvider>
   </QueryClientProvider>
 );
 


### PR DESCRIPTION
## Summary
- import the next-themes ThemeProvider in the root app component
- wrap existing providers with ThemeProvider so useTheme can access context

## Testing
- npm run lint *(fails: missing @eslint/js because npm install is blocked by registry access restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68ccacba0a208325a7bd02ee8786741d